### PR TITLE
Address the deprecation warnings of aws_iam_role

### DIFF
--- a/bin/miamtf-migrate
+++ b/bin/miamtf-migrate
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+$: << File.expand_path("#{File.dirname __FILE__}/../lib")
+require 'rubygems'
+require 'json'
+require 'miamtf'
+
+Version = Miamtf::VERSION
+
+tf = JSON.parse(STDIN.read, symbolize_names: true)
+local = tf[:locals][:miamtf]
+
+# The feature to migrate is very adhoc and not well defined.
+roles = local[:roles]
+policies = local[:managed_policies]
+instance_profiles = local[:instance_profiles]
+
+moved_roles = roles.keys.map do |role_name|
+  <<~HCL
+  moved {
+    from = aws_iam_role.#{role_name}
+    to   = aws_iam_role.miamtf["#{role_name}"]
+  }
+  HCL
+end
+moved_policies = policies.keys.map do |policy_name|
+  <<~HCL
+  moved {
+    from = aws_iam_policy.#{policy_name}
+    to   = aws_iam_policy.miamtf["#{policy_name}"]
+  }
+  HCL
+end
+moved_instance_profiles = instance_profiles.keys.map do |instance_profile_name|
+  <<~HCL
+  moved {
+    from = aws_iam_instance_profile.#{instance_profile_name}
+    to   = aws_iam_instance_profile.miamtf["#{instance_profile_name}"]
+  }
+  HCL
+end
+
+content = (moved_roles + moved_policies + moved_instance_profiles).join("\n")
+
+STDOUT.puts content

--- a/lib/miamtf.rb
+++ b/lib/miamtf.rb
@@ -1,5 +1,6 @@
 module Miamtf; end
 require "miamtf/version"
+require "miamtf/model"
 require "miamtf/dsl"
 require "miamtf/dsl/context"
 require "miamtf/dsl/context/role"

--- a/lib/miamtf/aux.tf
+++ b/lib/miamtf/aux.tf
@@ -1,0 +1,107 @@
+# This file is to be converted into JSON with hcl2json
+# hcl2json: https://github.com/tmccombs/hcl2json
+
+resource "aws_iam_role" "miamtf" {
+  for_each = local.miamtf.roles
+
+  # implicit
+  name = each.key
+
+  # required
+  assume_role_policy = jsonencode(each.value.assume_role_policy)
+
+  # optional
+  description           = each.value.description
+  force_detach_policies = each.value.force_detach_policies
+  max_session_duration  = each.value.max_session_duration
+  path                  = each.value.path
+  permissions_boundary  = each.value.permissions_boundary
+  tags                  = each.value.tags
+}
+
+resource "aws_iam_role_policy" "miamtf" {
+  for_each = {
+    for v in flatten([
+      for role_name, role in local.miamtf.roles : [
+        for policy_name, policy_document in role.inline_policies : {
+          role_name       = role_name
+          policy_name     = policy_name
+          policy_document = policy_document
+        }
+      ]
+    ]) : "${v.role_name}|${v.policy_name}" => v
+  }
+
+  # implicit
+  name = each.value.policy_name
+  role = each.value.role_name
+
+  # required
+  policy = jsonencode(each.value.policy_document)
+}
+
+resource "aws_iam_role_policies_exclusive" "miamtf" {
+  for_each = local.miamtf.roles
+
+  # implicit
+  role_name = each.key
+
+  # required
+  policy_names = keys(each.value.inline_policies)
+}
+
+resource "aws_iam_role_policy_attachment" "miamtf" {
+  for_each = {
+    for v in flatten([
+      for role_name, role in local.miamtf.roles : [
+        for policy_arn in role.managed_policy_arns : {
+          role_name  = role_name
+          policy_arn = policy_arn
+        }
+      ]
+    ]) : "${v.role_name}|${v.policy_arn}" => v
+  }
+
+  # implicit
+  role = each.value.role_name
+
+  # required
+  policy_arn = each.value.policy_arn
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "miamtf" {
+  for_each = local.miamtf.roles
+
+  # implicit
+  role_name = each.key
+
+  # required
+  policy_arns = each.value.managed_policy_arns
+}
+
+resource "aws_iam_policy" "miamtf" {
+  for_each = local.miamtf.managed_policies
+
+  # implicit
+  name = each.key
+
+  # required
+  policy = jsonencode(each.value.policy_document)
+
+  # optional
+  description = each.value.description
+  path        = each.value.path
+  tags        = each.value.tags
+}
+
+resource "aws_iam_instance_profile" "miamtf" {
+  for_each = local.miamtf.instance_profiles
+
+  # implicit
+  name = each.key
+  role = each.key
+
+  # optional
+  path = each.value.path
+  tags = each.value.tags
+}

--- a/lib/miamtf/aux.tf.json
+++ b/lib/miamtf/aux.tf.json
@@ -1,0 +1,79 @@
+{
+    "resource": {
+        "aws_iam_instance_profile": {
+            "miamtf": [
+                {
+                    "for_each": "${local.miamtf.instance_profiles}",
+                    "name": "${each.key}",
+                    "path": "${each.value.path}",
+                    "role": "${each.key}",
+                    "tags": "${each.value.tags}"
+                }
+            ]
+        },
+        "aws_iam_policy": {
+            "miamtf": [
+                {
+                    "description": "${each.value.description}",
+                    "for_each": "${local.miamtf.managed_policies}",
+                    "name": "${each.key}",
+                    "path": "${each.value.path}",
+                    "policy": "${jsonencode(each.value.policy_document)}",
+                    "tags": "${each.value.tags}"
+                }
+            ]
+        },
+        "aws_iam_role": {
+            "miamtf": [
+                {
+                    "assume_role_policy": "${jsonencode(each.value.assume_role_policy)}",
+                    "description": "${each.value.description}",
+                    "for_each": "${local.miamtf.roles}",
+                    "force_detach_policies": "${each.value.force_detach_policies}",
+                    "max_session_duration": "${each.value.max_session_duration}",
+                    "name": "${each.key}",
+                    "path": "${each.value.path}",
+                    "permissions_boundary": "${each.value.permissions_boundary}",
+                    "tags": "${each.value.tags}"
+                }
+            ]
+        },
+        "aws_iam_role_policies_exclusive": {
+            "miamtf": [
+                {
+                    "for_each": "${local.miamtf.roles}",
+                    "policy_names": "${keys(each.value.inline_policies)}",
+                    "role_name": "${each.key}"
+                }
+            ]
+        },
+        "aws_iam_role_policy": {
+            "miamtf": [
+                {
+                    "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_name, policy_document in role.inline_policies : {\n          role_name       = role_name\n          policy_name     = policy_name\n          policy_document = policy_document\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_name}\" =\u003e v\n  }}",
+                    "name": "${each.value.policy_name}",
+                    "policy": "${jsonencode(each.value.policy_document)}",
+                    "role": "${each.value.role_name}"
+                }
+            ]
+        },
+        "aws_iam_role_policy_attachment": {
+            "miamtf": [
+                {
+                    "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_arn in role.managed_policy_arns : {\n          role_name  = role_name\n          policy_arn = policy_arn\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_arn}\" =\u003e v\n  }}",
+                    "policy_arn": "${each.value.policy_arn}",
+                    "role": "${each.value.role_name}"
+                }
+            ]
+        },
+        "aws_iam_role_policy_attachments_exclusive": {
+            "miamtf": [
+                {
+                    "for_each": "${local.miamtf.roles}",
+                    "policy_arns": "${each.value.managed_policy_arns}",
+                    "role_name": "${each.key}"
+                }
+            ]
+        }
+    }
+}

--- a/lib/miamtf/dsl/context/managed_policy.rb
+++ b/lib/miamtf/dsl/context/managed_policy.rb
@@ -1,13 +1,11 @@
 class Miamtf::DSL::Context::ManagedPolicy
-  def initialize(name, &block)
-    @policy_name = name
+  def initialize(&block)
     @policy = instance_eval(&block)
   end
 
   def to_h
     {
-      name: @policy_name,
-      policy: @policy.to_json,
+      policy_document: @policy,
     }
   end
 end

--- a/lib/miamtf/dsl/context/role.rb
+++ b/lib/miamtf/dsl/context/role.rb
@@ -1,6 +1,5 @@
 class Miamtf::DSL::Context::Role
-  def initialize(name, &block)
-    @role_name = name
+  def initialize(&block)
     @assume_role_policy_document = nil
     @max_session_duration = nil
     @attached_managed_policies = []
@@ -10,17 +9,9 @@ class Miamtf::DSL::Context::Role
   end
 
   def to_h
-    inline_policy = @policies.map do |name, document|
-      {
-        name: name,
-        policy: document.to_json,
-      }
-    end
-
     {
-      name: @role_name,
-      assume_role_policy: @assume_role_policy_document.to_json,
-      inline_policy: inline_policy,
+      assume_role_policy: @assume_role_policy_document,
+      inline_policies: @policies,
       managed_policy_arns: @attached_managed_policies,
       max_session_duration: @max_session_duration,
       tags: @tags,

--- a/lib/miamtf/model.rb
+++ b/lib/miamtf/model.rb
@@ -1,0 +1,50 @@
+module Miamtf::Model
+  Root = Struct.new(
+    :roles, # map<string(role name), role: Role>
+    :managed_policies, # map<string(policy name), ManagedPolicy>
+    :instance_profiles, # map<string(profile name), InstanceProfile>
+
+    keyword_init: true
+  ) do
+    def to_h
+      {
+        roles: roles.transform_values(&:to_h),
+        managed_policies: managed_policies.transform_values(&:to_h),
+        instance_profiles: instance_profiles.transform_values(&:to_h),
+      }
+    end
+  end
+  Role = Struct.new(
+    # required
+    :assume_role_policy, # object(policy document to be converted to JSON)
+    # optional
+    :description, # string
+    :force_detach_policies, # boolean
+    :max_session_duration, # integer
+    :path, # string
+    :permissions_boundary, # string(ARN)
+    :tags, # map<string(name), string(value)>
+    # virtual
+    :inline_policies, # map<string(policy name), object(policy document to be converted to JSON)>
+    :managed_policy_arns, # list<string(ARN)>
+
+    keyword_init: true
+  )
+  ManagedPolicy = Struct.new(
+    # required
+    :policy_document, # object(policy document to be converted to JSON)
+    # optional
+    :description, # string
+    :path, # string
+    :tags, # map<string(name), string(value)>
+
+    keyword_init: true
+  )
+  InstanceProfile = Struct.new(
+    # optional
+    :path, # string
+    :tags, # map<string(name), string(value)>
+
+    keyword_init: true
+  )
+end


### PR DESCRIPTION
Fix: #1 

#2 でパッチをいただきましたが、以下の問題がありました:
- aws_iam_role_policy_attachment などの識別子を policy の ARN から文字列操作で組み立てていた
  - これが安定な操作とは限らない
- 新しい aws provider の aws_iam_role 等の構造が従来の実装から離れすぎており、小さい変更で対応するのは無理がある
  - 構造を変形するためのコードの可読性がどうしても悪くなる

上記の問題の修正を試みましたが、局所的な変更では問題は解決しませんでした。

そこで、このパッチでは方針を新たにしました:
- policy document 等のデータは一旦すべて terraform の locals に押し込む
  - このデータ構造は従来の構造をほとんどそのまま踏襲する（たとえば inline policy は role の配下に置いたままにする）
- 各種リソースは for_each を使って locals から展開する
  - miamtf のデータ構造と aws provider の resource の構造の変換が（比較的）宣言的な形で書ける
  - for_each を使うと識別子が `resource_type.name["${each.key}"]` という形になる
    - 重要なポイントはこの `each.key` の値ではより広い文字種が許されるということ
    - ARN のような記号を含む文字列をそのまま入れることができ、アドホックな文字列操作を最小化できる

つまり、このような `tf.json` が出力されるようになります。

```json
{
  "locals": {
    "miamtf": {
      "roles": {
        "ExampleRole": {
          "assume_role_policy": { }
          "inline_policies": { }
        }
      }
    }
  },
  "resource": {
    "aws_iam_role": {
      "miamtf": {
        "for_each": "(refers locals.miamtf.roles)"
      }
    }
  }
}
```

この方針の副作用として、リソースの識別子が変わってしまいます。
それに対応するために `miamtf-migrate` コマンドを追加しました。
`miamtf` コマンドが出力した `tf.json` を stdin に入力すると、新旧の識別子のリネームを行う `moved` ブロックの列を stdout に書き出します。
```
miamtf > iam.tf.json
miamtf-migrate iam.tf.json > migrate.tf
```
