### PR TITLE
Resolve role name via resource reference instead of value

### DIFF
--- a/lib/miamtf/aux.tf
+++ b/lib/miamtf/aux.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role_policy" "miamtf" {
 
   # implicit
   name = each.value.policy_name
-  role = each.value.role_name
+  role = aws_iam_role.miamtf[each.value.role_name].name
 
   # required
   policy = jsonencode(each.value.policy_document)
@@ -44,7 +44,7 @@ resource "aws_iam_role_policies_exclusive" "miamtf" {
   for_each = local.miamtf.roles
 
   # implicit
-  role_name = each.key
+  role_name = aws_iam_role.miamtf[each.key].name
 
   # required
   policy_names = keys(each.value.inline_policies)
@@ -63,7 +63,7 @@ resource "aws_iam_role_policy_attachment" "miamtf" {
   }
 
   # implicit
-  role = each.value.role_name
+  role = aws_iam_role.miamtf[each.value.role_name].name
 
   # required
   policy_arn = each.value.policy_arn
@@ -73,7 +73,7 @@ resource "aws_iam_role_policy_attachments_exclusive" "miamtf" {
   for_each = local.miamtf.roles
 
   # implicit
-  role_name = each.key
+  role_name = aws_iam_role.miamtf[each.key].name
 
   # required
   policy_arns = each.value.managed_policy_arns

--- a/lib/miamtf/aux.tf.json
+++ b/lib/miamtf/aux.tf.json
@@ -43,7 +43,7 @@
                 {
                     "for_each": "${local.miamtf.roles}",
                     "policy_names": "${keys(each.value.inline_policies)}",
-                    "role_name": "${each.key}"
+                    "role_name": "${aws_iam_role.miamtf[each.key].name}"
                 }
             ]
         },
@@ -53,7 +53,7 @@
                     "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_name, policy_document in role.inline_policies : {\n          role_name       = role_name\n          policy_name     = policy_name\n          policy_document = policy_document\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_name}\" =\u003e v\n  }}",
                     "name": "${each.value.policy_name}",
                     "policy": "${jsonencode(each.value.policy_document)}",
-                    "role": "${each.value.role_name}"
+                    "role": "${aws_iam_role.miamtf[each.value.role_name].name}"
                 }
             ]
         },
@@ -62,7 +62,7 @@
                 {
                     "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_arn in role.managed_policy_arns : {\n          role_name  = role_name\n          policy_arn = policy_arn\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_arn}\" =\u003e v\n  }}",
                     "policy_arn": "${each.value.policy_arn}",
-                    "role": "${each.value.role_name}"
+                    "role": "${aws_iam_role.miamtf[each.value.role_name].name}"
                 }
             ]
         },
@@ -71,7 +71,7 @@
                 {
                     "for_each": "${local.miamtf.roles}",
                     "policy_arns": "${each.value.managed_policy_arns}",
-                    "role_name": "${each.key}"
+                    "role_name": "${aws_iam_role.miamtf[each.key].name}"
                 }
             ]
         }


### PR DESCRIPTION
## 変更内容

policy および policy attachment resource から role を参照する際に、value ではなく、resource reference を利用するように変更

## 対処した問題

`0.2.0` の実装では、role と role_policy および role_policies_exclusive の依存関係が terraform 上で表現できていなかった。
これは、`role = each.value.role_name` のように値により、role name が参照されているためと考えられる。
そのため、新規の role 作成時に role に依存する resource の作成が失敗した 

```
aws_iam_role_policy.miamtf["Foo|policy-a"]: Creating...
aws_iam_role.miamtf["Foo"]: Creating...
aws_iam_role_policy.miamtf["Foo|policy-a"]: Creating...
aws_iam_role_policy_attachments_exclusive.miamtf["Foo"]: Creating...
aws_iam_role_policies_exclusive.miamtf["Foo"]: Creating...

 Error: creating AWS IAM (Identity & Access Management) Role Policies Exclusive ("Foo"): couldn't find resource
│ 
│   with aws_iam_role_policies_exclusive.miamtf["Foo"],
│   on iam.tf.json line 47, in resource.aws_iam_role_policies_exclusive.miamtf[0]:
│   47:         }
│ 
│ couldn't find resource
│ Error: putting IAM Role (Foo) Policy (policy-a): operation error IAM: PutRolePolicy, https response error StatusCode: 404, RequestID: [REDACTED], NoSuchEntity: The role with name Foo cannot be found.
│ 
│   with aws_iam_role_policy.miamtf["Foo|policy-a"],
│   on iam.tf.json line 57, in resource.aws_iam_role_policy.miamtf[0]:
│   57:         }
│ 
```

## 解決方法

そこで、role への依存を terraform に伝えるために、`aws_iam_role.miamtf[each.value.role_name].name` のように resource 参照を利用するように変更した。
これにより、terraform 上で resource 間の依存性が表現された

![tf-graph](https://github.com/user-attachments/assets/3c1d3fee-f862-4df8-997f-26c0e39ec556)

## 検討した他の実装方法

meta argument の `depends_on` を利用する方法も検討したが、resource reference で解決できると考えたので、採用しなかった。

## 懸念点

`aws_iam_role_policies_exclusive` は、厳密には、role および inline_policy に依存しているが、本対応では role のみへの依存しか表現できておらず、`policy_names` は依然として、値による参照のままである。
原則としては、すべての値参照は切り替えられるなら、resource reference を利用すべきで、難しければ、保守的に `depends_on` を用いると考えている。