### PR TITLE
Derive exclusive lists from per-item resources

### DIFF
--- a/lib/miamtf/aux.tf
+++ b/lib/miamtf/aux.tf
@@ -47,7 +47,13 @@ resource "aws_iam_role_policies_exclusive" "miamtf" {
   role_name = aws_iam_role.miamtf[each.key].name
 
   # required
-  policy_names = keys(each.value.inline_policies)
+  # Derived from the aws_iam_role_policy resources (not from locals) so that
+  # the exclusive list is reconciled only after every listed policy exists;
+  # otherwise adding a new inline policy races with this resource and the
+  # apply fails (PutRolePolicy is issued for the not-yet-created policy).
+  policy_names = [
+    for p in values(aws_iam_role_policy.miamtf) : p.name if p.role == each.key
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "miamtf" {
@@ -76,7 +82,11 @@ resource "aws_iam_role_policy_attachments_exclusive" "miamtf" {
   role_name = aws_iam_role.miamtf[each.key].name
 
   # required
-  policy_arns = each.value.managed_policy_arns
+  # Same as aws_iam_role_policies_exclusive: derived from the attachment
+  # resources so reconciliation happens only after all attachments exist.
+  policy_arns = [
+    for p in values(aws_iam_role_policy_attachment.miamtf) : p.policy_arn if p.role == each.key
+  ]
 }
 
 resource "aws_iam_policy" "miamtf" {

--- a/lib/miamtf/aux.tf.json
+++ b/lib/miamtf/aux.tf.json
@@ -42,7 +42,7 @@
             "miamtf": [
                 {
                     "for_each": "${local.miamtf.roles}",
-                    "policy_names": "${keys(each.value.inline_policies)}",
+                    "policy_names": "${[\n    for p in values(aws_iam_role_policy.miamtf) : p.name if p.role == each.key\n  ]}",
                     "role_name": "${aws_iam_role.miamtf[each.key].name}"
                 }
             ]
@@ -50,7 +50,7 @@
         "aws_iam_role_policy": {
             "miamtf": [
                 {
-                    "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_name, policy_document in role.inline_policies : {\n          role_name       = role_name\n          policy_name     = policy_name\n          policy_document = policy_document\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_name}\" =\u003e v\n  }}",
+                    "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_name, policy_document in role.inline_policies : {\n          role_name       = role_name\n          policy_name     = policy_name\n          policy_document = policy_document\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_name}\" => v\n  }}",
                     "name": "${each.value.policy_name}",
                     "policy": "${jsonencode(each.value.policy_document)}",
                     "role": "${aws_iam_role.miamtf[each.value.role_name].name}"
@@ -60,7 +60,7 @@
         "aws_iam_role_policy_attachment": {
             "miamtf": [
                 {
-                    "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_arn in role.managed_policy_arns : {\n          role_name  = role_name\n          policy_arn = policy_arn\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_arn}\" =\u003e v\n  }}",
+                    "for_each": "${{\n    for v in flatten([\n      for role_name, role in local.miamtf.roles : [\n        for policy_arn in role.managed_policy_arns : {\n          role_name  = role_name\n          policy_arn = policy_arn\n        }\n      ]\n    ]) : \"${v.role_name}|${v.policy_arn}\" => v\n  }}",
                     "policy_arn": "${each.value.policy_arn}",
                     "role": "${aws_iam_role.miamtf[each.value.role_name].name}"
                 }
@@ -70,7 +70,7 @@
             "miamtf": [
                 {
                     "for_each": "${local.miamtf.roles}",
-                    "policy_arns": "${each.value.managed_policy_arns}",
+                    "policy_arns": "${[\n    for p in values(aws_iam_role_policy_attachment.miamtf) : p.policy_arn if p.role == each.key\n  ]}",
                     "role_name": "${aws_iam_role.miamtf[each.key].name}"
                 }
             ]


### PR DESCRIPTION
## 対処した問題

`aws_iam_role_policies_exclusive` / `aws_iam_role_policy_attachments_exclusive` の `policy_names` / `policy_arns` が locals からの値参照のため、`aws_iam_role_policy` / `aws_iam_role_policy_attachment` への依存が terraform 上で表現されず、両者が並列に適用される。既存ロールに新しい inline policy を追加すると、exclusive 側がまだ存在しないポリシーを見て apply が失敗する:

```
Error: updating AWS IAM (Identity & Access Management) Role Policies Exclusive ("..."):
operation error IAM: PutRolePolicy, 1 validation error(s) found.
- missing required field, PutRolePolicyInput.PolicyDocument.
```

apply ログでは、新しい `aws_iam_role_policy` の `Creating...` 完了前に exclusive の `Modifying...` が始まっている。リトライでは収束する (ポリシーが既に存在するため) ので flaky に見えるが、ポリシー追加のたびに再現する。

これは #4 の「懸念点」に残されていた後半 (`policy_names` は依然として、値による参照のまま) が顕在化したもの。

## 解決方法

#4 と同じ原則 (値参照より resource reference) に従い、リストを per-item リソース自身から導出する:

```hcl
policy_names = [
  for p in values(aws_iam_role_policy.miamtf) : p.name if p.role == each.key
]
```

これにより depends_on なしで依存が表現される。

## 検証

- 実運用の IAMFile (inline policy / managed policy attachment 混在) から生成した構成で `terraform validate` が通ることを確認
- `policy_names` / `policy_arns` は provider スキーマ上 set of string のため、導出順序の違いによる余計な diff は発生しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)